### PR TITLE
chore: bump version to 0.2.4

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,29 @@
+# Copilot Workflow Rules for mpbt-launcher
+
+## Branch & PR Rules
+
+- **Never commit directly to `master`.** Every change goes on a feature/fix/chore branch.
+- **Never merge or close a PR.** Only the human merges. Open the PR and stop.
+- After pushing a branch, open a PR and request review — then wait.
+
+## Version Bumps
+
+- Version is tracked in 5 files — bump all together:
+  - `package.json`
+  - `package-lock.json` (2 occurrences: top-level and inside `"packages": { "": { ... } }`)
+  - `src-tauri/tauri.conf.json`
+  - `src-tauri/Cargo.toml`
+  - `src-tauri/Cargo.lock` (only the `[[package]] name = "mpbt-launcher"` entry)
+- Always bump on a branch + PR, never directly on master.
+- The release workflow triggers on every push to master and tags `v{version}`.
+  Pushing the same version twice replaces the release silently — existing users
+  on that version will NOT receive an auto-update notification.
+
+## Versioning Strategy
+
+- Direct-to-master commits that change launcher behavior require a subsequent
+  version bump PR so auto-update triggers for existing users.
+
+## Commit Style
+
+- Use conventional commits: `fix(scope): message`, `chore: message`, `feat(scope): message`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mpbt-launcher",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mpbt-launcher",
-      "version": "0.2.4",
+      "version": "0.2.5",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@tauri-apps/api": "^2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mpbt-launcher",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mpbt-launcher",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@tauri-apps/api": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mpbt-launcher",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Game launcher for MPBT Solaris VII Revival — handles authentication, configuration, and launching MPBTWIN.EXE",
   "author": "Ken Human",
   "license": "AGPL-3.0-only",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mpbt-launcher",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Game launcher for MPBT Solaris VII Revival — handles authentication, configuration, and launching MPBTWIN.EXE",
   "author": "Ken Human",
   "license": "AGPL-3.0-only",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2004,7 +2004,7 @@ dependencies = [
 
 [[package]]
 name = "mpbt-launcher"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "reqwest 0.12.28",
  "serde",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2004,7 +2004,7 @@ dependencies = [
 
 [[package]]
 name = "mpbt-launcher"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "reqwest 0.12.28",
  "serde",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mpbt-launcher"
-version = "0.2.3"
+version = "0.2.4"
 edition = "2021"
 
 [lib]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mpbt-launcher"
-version = "0.2.4"
+version = "0.2.5"
 edition = "2021"
 
 [lib]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MPBT Launcher",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "identifier": "com.mpbt.launcher",
   "build": {
     "frontendDist": "../out",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MPBT Launcher",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "identifier": "com.mpbt.launcher",
   "build": {
     "frontendDist": "../out",


### PR DESCRIPTION
Bumps version from 0.2.3 to 0.2.4 so that users who installed v0.2.3 receive an auto-update notification with the windowed mode CRC bypass fix (v1.23 `0x1B` opcode variant, committed directly to master in 8824a43).

Also adds `.github/copilot-instructions.md` with workflow rules to prevent future direct-to-master commits.