### PR TITLE
fix: re-fetch client config live when Web URL changes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mpbt-launcher",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mpbt-launcher",
-      "version": "0.2.5",
+      "version": "0.2.6",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@tauri-apps/api": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mpbt-launcher",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "Game launcher for MPBT Solaris VII Revival — handles authentication, configuration, and launching MPBTWIN.EXE",
   "author": "Ken Human",
   "license": "AGPL-3.0-only",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2004,7 +2004,7 @@ dependencies = [
 
 [[package]]
 name = "mpbt-launcher"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "reqwest 0.12.28",
  "serde",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mpbt-launcher"
-version = "0.2.5"
+version = "0.2.6"
 edition = "2021"
 
 [lib]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MPBT Launcher",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "identifier": "com.mpbt.launcher",
   "build": {
     "frontendDist": "../out",

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -122,9 +122,19 @@ export default function LauncherPage() {
       }
     }).catch(() => {});
 
-    // Fetch server config and news from the website
-    const base = p.webUrl.replace(/\/+$/, "");
-    fetch(`${base}/api/client-config`)
+  }, []);
+
+  // Re-fetch server config and news whenever the Web URL changes (after hydration).
+  // Clears resolved values immediately so the launch button disables while in flight.
+  useEffect(() => {
+    if (!hydrated) return;
+    setResolvedApiUrl("");
+    setResolvedServer("");
+    const base = webUrl.replace(/\/+$/, "");
+    const controller = new AbortController();
+    const { signal } = controller;
+
+    fetch(`${base}/api/client-config`, { signal })
       .then((r) => (r.ok ? r.json() : Promise.reject()))
       .then((cfg: ClientConfig) => {
         setResolvedApiUrl(cfg.apiUrl);
@@ -132,11 +142,13 @@ export default function LauncherPage() {
       })
       .catch(() => { /* best-effort; launch button stays disabled */ });
 
-    fetch(`${base}/api/articles?limit=2`)
+    fetch(`${base}/api/articles?limit=2`, { signal })
       .then((r) => (r.ok ? r.json() : Promise.reject()))
       .then((articles: NewsArticle[]) => setNews(articles))
       .catch(() => { /* best-effort */ });
-  }, []);
+
+    return () => controller.abort();
+  }, [hydrated, webUrl]);
 
   // Persist whenever any relevant value changes (after hydration)
   useEffect(() => {


### PR DESCRIPTION
## Summary

Fixes #6.

### Root Cause

`/api/client-config` and `/api/articles` were fetched once inside the one-time hydration `useEffect(fn, [])` using the localStorage snapshot of `webUrl`. Editing the **Web URL** field after startup persisted the new value to localStorage but never re-triggered the fetches, leaving `resolvedApiUrl` and `resolvedServer` pointing at the old server until the launcher was restarted.

### Fix

Moved both fetches into a dedicated `useEffect` keyed on `[hydrated, webUrl]`:

- **Immediate clear** — sets `resolvedApiUrl`/`resolvedServer` to `""` as soon as `webUrl` changes, disabling the launch button while the re-fetch is in flight.
- **Live re-fetch** — fetches `/api/client-config` and `/api/articles` from the new base URL.
- **AbortController cleanup** — cancels any in-flight fetch if the URL changes again before the response arrives, preventing stale state from a slow previous request overwriting the new one.

No restart required — the launcher picks up the new URL immediately.

### Change

| File | Change |
|---|---|
| `src/app/page.tsx` | Remove config/news fetch from hydration effect; add `useEffect([hydrated, webUrl])` with AbortController |