### PR TITLE
feat: add resolution / display-mode options

### DIFF
--- a/native/ddraw.cpp
+++ b/native/ddraw.cpp
@@ -168,6 +168,21 @@ static void ReadConfig() {
 // Helpers
 // ============================================================================
 
+// Compute the destination rectangle for an aspect-correct scaled blit of
+// (srcW x srcH) into a window of (winW x winH).
+struct ScaleRect { int x, y, w, h; };
+static ScaleRect ComputeScaleRect(int srcW, int srcH, int winW, int winH) {
+    double scaleX = (double)winW / srcW;
+    double scaleY = (double)winH / srcH;
+    double scale  = (scaleX < scaleY) ? scaleX : scaleY;
+    ScaleRect r;
+    r.w = (int)(srcW * scale);
+    r.h = (int)(srcH * scale);
+    r.x = (winW - r.w) / 2;
+    r.y = (winH - r.h) / 2;
+    return r;
+}
+
 // Render the current back-buffer to an arbitrary DC, scaling to (winW x winH)
 // with aspect-correct letterboxing (black bars) if needed.
 static void RenderToHDC(HDC wdc, int winW, int winH) {
@@ -182,34 +197,52 @@ static void RenderToHDC(HDC wdc, int winW, int winH) {
         return;
     }
 
-    // Aspect-correct scale
-    double scaleX = (double)winW / srcW;
-    double scaleY = (double)winH / srcH;
-    double scale  = (scaleX < scaleY) ? scaleX : scaleY;
-    int dstW = (int)(srcW * scale);
-    int dstH = (int)(srcH * scale);
-    int dstX = (winW - dstW) / 2;
-    int dstY = (winH - dstH) / 2;
+    ScaleRect dst = ComputeScaleRect(srcW, srcH, winW, winH);
 
     // Fill letterbox bars with black
     HBRUSH black = (HBRUSH)GetStockObject(BLACK_BRUSH);
-    if (dstX > 0) {
-        RECT r1 = {0, 0, dstX, winH};
-        RECT r2 = {dstX + dstW, 0, winW, winH};
+    if (dst.x > 0) {
+        RECT r1 = {0, 0, dst.x, winH};
+        RECT r2 = {dst.x + dst.w, 0, winW, winH};
         FillRect(wdc, &r1, black);
         FillRect(wdc, &r2, black);
     }
-    if (dstY > 0) {
-        RECT r1 = {0, 0, winW, dstY};
-        RECT r2 = {0, dstY + dstH, winW, winH};
+    if (dst.y > 0) {
+        RECT r1 = {0, 0, winW, dst.y};
+        RECT r2 = {0, dst.y + dst.h, winW, winH};
         FillRect(wdc, &r1, black);
         FillRect(wdc, &r2, black);
     }
 
     SetStretchBltMode(wdc, HALFTONE);
     SetBrushOrgEx(wdc, 0, 0, nullptr);
-    StretchBlt(wdc, dstX, dstY, dstW, dstH,
+    StretchBlt(wdc, dst.x, dst.y, dst.w, dst.h,
                g_backDib.hdc, 0, 0, srcW, srcH, SRCCOPY);
+}
+
+// Transform a window-space mouse coordinate back to game (640x480) space.
+// Returns the remapped lParam; if outside the game area the coordinate is
+// clamped to the nearest edge so the game always receives a valid position.
+static LPARAM RemapMouseCoord(LPARAM lp) {
+    int winW = (g_targetW > 0) ? g_targetW : g_dispW;
+    int winH = (g_targetH > 0) ? g_targetH : g_dispH;
+    // No scaling active — pass through unchanged.
+    if (winW == g_dispW && winH == g_dispH) return lp;
+
+    int mx = (int)(short)LOWORD(lp);
+    int my = (int)(short)HIWORD(lp);
+
+    ScaleRect dst = ComputeScaleRect(g_dispW, g_dispH, winW, winH);
+
+    // Map from window coords into game coords
+    int gx = (dst.w > 0) ? (mx - dst.x) * g_dispW / dst.w : 0;
+    int gy = (dst.h > 0) ? (my - dst.y) * g_dispH / dst.h : 0;
+
+    // Clamp to valid game area
+    if (gx < 0) gx = 0; else if (gx >= g_dispW) gx = g_dispW - 1;
+    if (gy < 0) gy = 0; else if (gy >= g_dispH) gy = g_dispH - 1;
+
+    return MAKELPARAM(gx, gy);
 }
 
 // Known addresses inside MPBTWIN.EXE (.data segment, image base 0x00400000)
@@ -243,10 +276,21 @@ static void BlitToWindow() {
 // Bit 1 of the flags word is the WinMain quit flag.
 #define GAME_FLAGS_ADDR_QUIT_BIT 0x02
 
-// Subclass WndProc: handle WM_PAINT from our DIB; suppress WM_ACTIVATEAPP
-// deactivation so the game's rendering-enable bit (bit 0) stays set in
-// windowed mode; force-quit when the window is destroyed.
+// Subclass WndProc: handle WM_PAINT from our DIB; remap mouse coords when
+// scaling is active; suppress WM_ACTIVATEAPP deactivation so the game's
+// rendering-enable bit (bit 0) stays set in windowed mode; force-quit when
+// the window is destroyed.
 static LRESULT CALLBACK ShimWndProc(HWND hwnd, UINT msg, WPARAM wp, LPARAM lp) {
+    // Remap mouse coordinates from window space back to game (640x480) space
+    // whenever the window is larger than the native game resolution.
+    switch (msg) {
+    case WM_MOUSEMOVE:
+    case WM_LBUTTONDOWN: case WM_LBUTTONUP: case WM_LBUTTONDBLCLK:
+    case WM_RBUTTONDOWN: case WM_RBUTTONUP: case WM_RBUTTONDBLCLK:
+    case WM_MBUTTONDOWN: case WM_MBUTTONUP: case WM_MBUTTONDBLCLK:
+        lp = RemapMouseCoord(lp);
+        break;
+    }
     if (msg == WM_PAINT) {
         PAINTSTRUCT ps;
         HDC hdc = BeginPaint(hwnd, &ps);

--- a/native/ddraw.cpp
+++ b/native/ddraw.cpp
@@ -961,11 +961,24 @@ static void PatchGameIAT()
     }
 }
 
+// True once ReadConfig() has been called (guards against multiple calls).
+static bool g_configLoaded = false;
+
+// Ensure config is loaded exactly once.  Safe to call from any context
+// (DirectDrawCreate, SetCooperativeLevel) because by that point the loader
+// lock is no longer held.
+static void EnsureConfig() {
+    if (g_configLoaded) return;
+    g_configLoaded = true;
+    ReadConfig();
+}
+
 BOOL WINAPI DllMain(HINSTANCE, DWORD fdwReason, LPVOID)
 {
     if (fdwReason == DLL_PROCESS_ATTACH) {
+        // Keep DllMain minimal — no file I/O here.
+        // Config is loaded lazily on the first DirectDrawCreate call.
         DbLog("ddraw_shim loaded");
-        ReadConfig();
         PatchGameIAT();
     }
     return TRUE;
@@ -980,6 +993,7 @@ extern "C" {
 HRESULT WINAPI DirectDrawCreate(GUID* lpGUID, LPDIRECTDRAW* lplpDD,
                                  IUnknown* pUnkOuter) {
     if (!lplpDD) return DDERR_INVALIDPARAMS;
+    EnsureConfig();
     *lplpDD = new FakeDD();
     return S_OK;
 }

--- a/native/ddraw.cpp
+++ b/native/ddraw.cpp
@@ -112,6 +112,12 @@ static int     g_dispW = 640;
 static int     g_dispH = 480;
 static int     g_bpp   = 8;
 
+// Target window dimensions read from ddraw.ini (0 = use game resolution)
+static int     g_targetW = 0;
+static int     g_targetH = 0;
+// True when the window should cover the full monitor without chrome
+static bool    g_borderlessFullscreen = false;
+
 // Shared back-buffer DIB (primary + back surface both refer here)
 static DibBuf  g_backDib;
 
@@ -122,8 +128,89 @@ static RGBQUAD g_pal[256];
 static WNDPROC g_origWndProc = nullptr;
 
 // ============================================================================
+// Config reader — parses ddraw.ini placed alongside the game EXE
+// ============================================================================
+
+static void ReadConfig() {
+    // Derive ini path from the game process EXE directory.
+    char exePath[MAX_PATH] = {};
+    GetModuleFileNameA(NULL, exePath, sizeof(exePath));
+    char* lastSep = strrchr(exePath, '\\');
+    if (!lastSep) return;
+    *(lastSep + 1) = '\0'; // keep trailing backslash
+
+    char cfgPath[MAX_PATH];
+    _snprintf(cfgPath, sizeof(cfgPath) - 1, "%sddraw.ini", exePath);
+    cfgPath[sizeof(cfgPath) - 1] = '\0';
+
+    char modeBuf[64] = {};
+    GetPrivateProfileStringA("display", "mode", "", modeBuf, sizeof(modeBuf), cfgPath);
+    if (_stricmp(modeBuf, "fullscreen-window") == 0) {
+        g_borderlessFullscreen = true;
+        g_targetW = GetSystemMetrics(SM_CXSCREEN);
+        g_targetH = GetSystemMetrics(SM_CYSCREEN);
+        DbLog("ReadConfig: fullscreen-window %dx%d", g_targetW, g_targetH);
+        return;
+    }
+
+    char wBuf[32] = {}, hBuf[32] = {};
+    GetPrivateProfileStringA("display", "width",  "0", wBuf, sizeof(wBuf), cfgPath);
+    GetPrivateProfileStringA("display", "height", "0", hBuf, sizeof(hBuf), cfgPath);
+    g_targetW = atoi(wBuf);
+    g_targetH = atoi(hBuf);
+    if (g_targetW > 0 && g_targetH > 0)
+        DbLog("ReadConfig: windowed %dx%d", g_targetW, g_targetH);
+    else
+        DbLog("ReadConfig: no scaling (game resolution)");
+}
+
+// ============================================================================
 // Helpers
 // ============================================================================
+
+// Render the current back-buffer to an arbitrary DC, scaling to (winW x winH)
+// with aspect-correct letterboxing (black bars) if needed.
+static void RenderToHDC(HDC wdc, int winW, int winH) {
+    if (!g_backDib.hdc) return;
+    int srcW = g_backDib.w, srcH = g_backDib.h;
+    if (winW <= 0) winW = srcW;
+    if (winH <= 0) winH = srcH;
+
+    if (winW == srcW && winH == srcH) {
+        // 1:1 — plain fast copy
+        BitBlt(wdc, 0, 0, srcW, srcH, g_backDib.hdc, 0, 0, SRCCOPY);
+        return;
+    }
+
+    // Aspect-correct scale
+    double scaleX = (double)winW / srcW;
+    double scaleY = (double)winH / srcH;
+    double scale  = (scaleX < scaleY) ? scaleX : scaleY;
+    int dstW = (int)(srcW * scale);
+    int dstH = (int)(srcH * scale);
+    int dstX = (winW - dstW) / 2;
+    int dstY = (winH - dstH) / 2;
+
+    // Fill letterbox bars with black
+    HBRUSH black = (HBRUSH)GetStockObject(BLACK_BRUSH);
+    if (dstX > 0) {
+        RECT r1 = {0, 0, dstX, winH};
+        RECT r2 = {dstX + dstW, 0, winW, winH};
+        FillRect(wdc, &r1, black);
+        FillRect(wdc, &r2, black);
+    }
+    if (dstY > 0) {
+        RECT r1 = {0, 0, winW, dstY};
+        RECT r2 = {0, dstY + dstH, winW, winH};
+        FillRect(wdc, &r1, black);
+        FillRect(wdc, &r2, black);
+    }
+
+    SetStretchBltMode(wdc, HALFTONE);
+    SetBrushOrgEx(wdc, 0, 0, nullptr);
+    StretchBlt(wdc, dstX, dstY, dstW, dstH,
+               g_backDib.hdc, 0, 0, srcW, srcH, SRCCOPY);
+}
 
 // Known addresses inside MPBTWIN.EXE (.data segment, image base 0x00400000)
 #define GAME_FLAGS_ADDR    ((volatile DWORD*)0x0047a7c8)  // bit0=render enabled, bit1=quit
@@ -146,9 +233,10 @@ static void BlitToWindow() {
         DbLog("BTW #%d  state=%d flags=0x%08x guard=0x%x sprites=%d prim_center=0x%02x",
               s_btwCount, (int)state, (unsigned)flags, (unsigned)guard, (int)sprites, (unsigned)cpx);
     }
+    int winW = (g_targetW > 0) ? g_targetW : g_backDib.w;
+    int winH = (g_targetH > 0) ? g_targetH : g_backDib.h;
     HDC wdc = GetDC(g_hwnd);
-    BitBlt(wdc, 0, 0, g_backDib.w, g_backDib.h,
-           g_backDib.hdc, 0, 0, SRCCOPY);
+    RenderToHDC(wdc, winW, winH);
     ReleaseDC(g_hwnd, wdc);
 }
 
@@ -162,9 +250,9 @@ static LRESULT CALLBACK ShimWndProc(HWND hwnd, UINT msg, WPARAM wp, LPARAM lp) {
     if (msg == WM_PAINT) {
         PAINTSTRUCT ps;
         HDC hdc = BeginPaint(hwnd, &ps);
-        if (g_backDib.hdc)
-            BitBlt(hdc, 0, 0, g_backDib.w, g_backDib.h,
-                   g_backDib.hdc, 0, 0, SRCCOPY);
+        int winW = (g_targetW > 0) ? g_targetW : g_backDib.w;
+        int winH = (g_targetH > 0) ? g_targetH : g_backDib.h;
+        RenderToHDC(hdc, winW, winH);
         EndPaint(hwnd, &ps);
         return 0;
     }
@@ -678,19 +766,32 @@ public:
         DbLog("SetCooperativeLevel hwnd=0x%p", (void*)hwnd);
         g_hwnd = hwnd;
 
-        // Restyle the game's window: remove popup/exclusive style, add normal chrome
-        LONG style = GetWindowLongA(hwnd, GWL_STYLE);
-        style &= ~(WS_POPUP | WS_DLGFRAME);
-        style |= WS_OVERLAPPED | WS_CAPTION | WS_SYSMENU | WS_MINIMIZEBOX;
-        SetWindowLongA(hwnd, GWL_STYLE, style);
-        SetWindowLongA(hwnd, GWL_EXSTYLE, 0);
+        int wndW = (g_targetW > 0) ? g_targetW : g_dispW;
+        int wndH = (g_targetH > 0) ? g_targetH : g_dispH;
 
-        // Size the window so the client area exactly fits the display resolution
-        RECT r = { 0, 0, g_dispW, g_dispH };
-        AdjustWindowRect(&r, (DWORD)style, FALSE);
-        SetWindowPos(hwnd, HWND_TOP, CW_USEDEFAULT, CW_USEDEFAULT,
-                     r.right - r.left, r.bottom - r.top,
-                     SWP_NOMOVE | SWP_FRAMECHANGED | SWP_SHOWWINDOW);
+        if (g_borderlessFullscreen) {
+            // Borderless fullscreen: no title bar, no chrome, covers the whole monitor
+            LONG style = GetWindowLongA(hwnd, GWL_STYLE);
+            style &= ~(WS_CAPTION | WS_SYSMENU | WS_MINIMIZEBOX | WS_THICKFRAME | WS_DLGFRAME);
+            style |= WS_POPUP;
+            SetWindowLongA(hwnd, GWL_STYLE, style);
+            SetWindowLongA(hwnd, GWL_EXSTYLE, 0);
+            SetWindowPos(hwnd, HWND_TOPMOST, 0, 0, wndW, wndH,
+                         SWP_FRAMECHANGED | SWP_SHOWWINDOW);
+        } else {
+            // Normal windowed mode
+            LONG style = GetWindowLongA(hwnd, GWL_STYLE);
+            style &= ~(WS_POPUP | WS_DLGFRAME);
+            style |= WS_OVERLAPPED | WS_CAPTION | WS_SYSMENU | WS_MINIMIZEBOX;
+            SetWindowLongA(hwnd, GWL_STYLE, style);
+            SetWindowLongA(hwnd, GWL_EXSTYLE, 0);
+
+            RECT r = { 0, 0, wndW, wndH };
+            AdjustWindowRect(&r, (DWORD)style, FALSE);
+            SetWindowPos(hwnd, HWND_TOP, CW_USEDEFAULT, CW_USEDEFAULT,
+                         r.right - r.left, r.bottom - r.top,
+                         SWP_NOMOVE | SWP_FRAMECHANGED | SWP_SHOWWINDOW);
+        }
 
         // Bring window to foreground so the game receives WM_ACTIVATEAPP(1).
         // The game's WndProc sets DAT_0047a7c8 bit 0 on that message; all
@@ -717,8 +818,9 @@ public:
         DbLog("SetDisplayMode %dx%dx%d", (int)w, (int)h, (int)bpp);
         g_dispW = (int)w; g_dispH = (int)h; g_bpp = (int)bpp;
 
-        // Resize the window client area to match
-        if (g_hwnd) {
+        // Only resize the window when no target scaling is configured;
+        // SetCooperativeLevel already set the window to the target size.
+        if (g_hwnd && g_targetW == 0) {
             LONG style = GetWindowLongA(g_hwnd, GWL_STYLE);
             RECT r = { 0, 0, (LONG)w, (LONG)h };
             AdjustWindowRect(&r, (DWORD)style, FALSE);
@@ -819,6 +921,7 @@ BOOL WINAPI DllMain(HINSTANCE, DWORD fdwReason, LPVOID)
 {
     if (fdwReason == DLL_PROCESS_ATTACH) {
         DbLog("ddraw_shim loaded");
+        ReadConfig();
         PatchGameIAT();
     }
     return TRUE;

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -23,15 +23,17 @@ pub async fn login(
 }
 
 /// Called on launcher startup: remove any previously-placed ddraw.dll shim
-/// from the game directory so a direct run of MPBTWIN.EXE always uses the
-/// system DirectDraw (full-screen mode).
+/// and ddraw.ini config from the game directory so a direct run of MPBTWIN.EXE
+/// always uses the system DirectDraw (full-screen mode).
 #[tauri::command]
 pub fn cleanup_ddraw(game_exe: String) {
     let exe_path = std::path::Path::new(&game_exe);
     if let Some(game_dir) = exe_path.parent() {
-        let shim = game_dir.join("ddraw.dll");
-        if shim.exists() {
-            let _ = std::fs::remove_file(shim);
+        for name in &["ddraw.dll", "ddraw.ini"] {
+            let path = game_dir.join(name);
+            if path.exists() {
+                let _ = std::fs::remove_file(path);
+            }
         }
     }
 }
@@ -46,7 +48,7 @@ pub async fn launch_game(
     server: String,   // e.g. "127.0.0.1:2000"
     api_url: String,  // e.g. "http://localhost:3001"
     game_exe: String, // e.g. "C:\\MPBT\\MPBTWIN.EXE"
-    windowed: bool,   // true → use ddraw shim for windowed mode
+    display_mode: String, // e.g. "fullscreen", "window-1920x1080", "window-fullscreen"
 ) -> Result<(), String> {
     // 1. Authenticate and retrieve email for play.pcgi
     let info = do_login(&api_url, &username, &password).await?;
@@ -87,7 +89,7 @@ pub async fn launch_game(
         .map_err(|e| format!("Failed to write {}: {e}", pcgi_path.display()))?;
 
     // 5. Deploy (or remove) shim and launch
-    crate::game::launch_game(exe_path, windowed, &pcgi_path)?;
+    crate::game::launch_game(exe_path, &display_mode, &pcgi_path)?;
 
     // Close the launcher window.  Spawn a short-lived thread so the IPC
     // response can be flushed to the frontend before the window is torn down.

--- a/src-tauri/src/game.rs
+++ b/src-tauri/src/game.rs
@@ -107,18 +107,44 @@ fn windowed_exe(original: &std::path::Path) -> Result<std::path::PathBuf, String
     Ok(patched)
 }
 
+/// Return the `[display]` section content for `ddraw.ini` given a display mode
+/// string, or `None` if the mode is "fullscreen" (no shim needed).
+fn ddraw_ini_content(display_mode: &str) -> Option<String> {
+    match display_mode {
+        "fullscreen" => None,
+        "window-fullscreen" => Some("[display]\nmode=fullscreen-window\n".into()),
+        other => {
+            // Expect "window-WxH" e.g. "window-1920x1080"
+            if let Some(size) = other.strip_prefix("window-") {
+                if let Some((w, h)) = size.split_once('x') {
+                    return Some(format!("[display]\nwidth={}\nheight={}\n", w, h));
+                }
+            }
+            // Unknown windowed mode — use plain windowed at game resolution
+            Some("[display]\n".into())
+        }
+    }
+}
+
 #[cfg(target_os = "windows")]
 pub fn launch_game(
     game_exe: &std::path::Path,
-    windowed: bool,
+    display_mode: &str,
     pcgi_path: &std::path::Path,
 ) -> Result<(), String> {
     let game_dir = game_exe.parent().ok_or("game_exe has no parent directory")?;
     let dest_ddraw = game_dir.join("ddraw.dll");
+    let dest_ini   = game_dir.join("ddraw.ini");
 
     let exe_to_launch: std::path::PathBuf;
 
-    if windowed {
+    if let Some(ini_content) = ddraw_ini_content(display_mode) {
+        // Windowed mode: write config, deploy shim, use patched EXE.
+
+        // Write ddraw.ini (mode/resolution config for the shim).
+        std::fs::write(&dest_ini, &ini_content)
+            .map_err(|e| format!("Failed to write ddraw.ini: {e}"))?;
+
         // Write the ddraw shim.  Sharing violation is non-fatal — another
         // instance already placed it.
         if let Err(e) = std::fs::write(&dest_ddraw, DDRAW_DLL_BYTES) {
@@ -130,10 +156,9 @@ pub fn launch_game(
         // Use the patched copy so we never touch a running EXE.
         exe_to_launch = windowed_exe(game_exe)?;
     } else {
-        // Full-screen mode: remove the ddraw shim and use the original EXE.
-        if dest_ddraw.exists() {
-            let _ = std::fs::remove_file(&dest_ddraw);
-        }
+        // Full-screen mode: remove the ddraw shim and config, use original EXE.
+        if dest_ddraw.exists() { let _ = std::fs::remove_file(&dest_ddraw); }
+        if dest_ini.exists()   { let _ = std::fs::remove_file(&dest_ini); }
         exe_to_launch = game_exe.to_path_buf();
     }
 
@@ -149,7 +174,7 @@ pub fn launch_game(
 #[cfg(not(target_os = "windows"))]
 pub fn launch_game(
     _game_exe: &std::path::Path,
-    _windowed: bool,
+    _display_mode: &str,
     _pcgi_path: &std::path::Path,
 ) -> Result<(), String> {
     Err("MPBT only runs on Windows".to_string())

--- a/src-tauri/src/game.rs
+++ b/src-tauri/src/game.rs
@@ -117,10 +117,12 @@ fn ddraw_ini_content(display_mode: &str) -> Option<String> {
             // Expect "window-WxH" e.g. "window-1920x1080"
             if let Some(size) = other.strip_prefix("window-") {
                 if let Some((w, h)) = size.split_once('x') {
-                    return Some(format!("[display]\nwidth={}\nheight={}\n", w, h));
+                    if let (Ok(w), Ok(h)) = (w.parse::<u32>(), h.parse::<u32>()) {
+                        return Some(format!("[display]\nwidth={}\nheight={}\n", w, h));
+                    }
                 }
             }
-            // Unknown windowed mode — use plain windowed at game resolution
+            // Unknown or malformed windowed mode — use plain windowed at game resolution
             Some("[display]\n".into())
         }
     }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -12,13 +12,24 @@ interface ClientConfig {
   gameServer: string;
 }
 
+const DISPLAY_MODES = [
+  { value: "fullscreen",        label: "Fullscreen (640×480 native)" },
+  { value: "window-640x480",    label: "Windowed 640×480" },
+  { value: "window-1024x768",   label: "Windowed 1024×768" },
+  { value: "window-1280x960",   label: "Windowed 1280×960" },
+  { value: "window-1920x1080",  label: "Windowed 1920×1080 (letterboxed)" },
+  { value: "window-fullscreen", label: "Windowed Fullscreen" },
+] as const;
+
+type DisplayModeValue = typeof DISPLAY_MODES[number]["value"];
+
 interface Prefs {
   username: string;
   password: string;
   webUrl: string;
   gameExe: string;
   savePassword: boolean;
-  windowed: boolean;
+  displayMode: DisplayModeValue;
 }
 
 interface NewsArticle {
@@ -32,22 +43,31 @@ interface UpdateInfo {
   install: () => Promise<void>;
 }
 
+function isValidDisplayMode(v: unknown): v is DisplayModeValue {
+  return DISPLAY_MODES.some((m) => m.value === v);
+}
+
 function loadPrefs(): Prefs {
   try {
     const raw = localStorage.getItem(STORAGE_KEY);
     if (raw) {
-      const p = JSON.parse(raw) as Partial<Prefs>;
+      const p = JSON.parse(raw) as Partial<Prefs> & { windowed?: boolean };
+      // Migrate old boolean windowed pref
+      const migratedMode: DisplayModeValue =
+        isValidDisplayMode(p.displayMode) ? p.displayMode
+        : p.windowed ? "window-640x480"
+        : "fullscreen";
       return {
         username:     p.username     ?? "",
         password:     p.savePassword ? (p.password ?? "") : "",
         webUrl:       p.webUrl       ?? DEFAULT_WEB_URL,
         gameExe:      p.gameExe      ?? DEFAULT_GAME,
         savePassword: p.savePassword ?? false,
-        windowed:     p.windowed     ?? false,
+        displayMode:  migratedMode,
       };
     }
   } catch { /* ignore */ }
-  return { username: "", password: "", webUrl: DEFAULT_WEB_URL, gameExe: DEFAULT_GAME, savePassword: false, windowed: false };
+  return { username: "", password: "", webUrl: DEFAULT_WEB_URL, gameExe: DEFAULT_GAME, savePassword: false, displayMode: "fullscreen" };
 }
 
 function savePrefs(prefs: Prefs) {
@@ -63,7 +83,7 @@ export default function LauncherPage() {
   const [webUrl,       setWebUrl]       = useState(DEFAULT_WEB_URL);
   const [gameExe,      setGameExe]      = useState(DEFAULT_GAME);
   const [savePassword, setSavePassword] = useState(false);
-  const [windowed,     setWindowed]     = useState(false);
+  const [displayMode,  setDisplayMode]  = useState<DisplayModeValue>("fullscreen");
   const [advanced,     setAdvanced]     = useState(false);
   const [hydrated,     setHydrated]     = useState(false);
 
@@ -93,7 +113,7 @@ export default function LauncherPage() {
     setWebUrl(p.webUrl);
     setGameExe(p.gameExe);
     setSavePassword(p.savePassword);
-    setWindowed(p.windowed);
+    setDisplayMode(p.displayMode);
     setHydrated(true);
 
     // Remove any leftover ddraw.dll shim on every startup so a direct run
@@ -153,8 +173,8 @@ export default function LauncherPage() {
   // Persist whenever any relevant value changes (after hydration)
   useEffect(() => {
     if (!hydrated) return;
-    savePrefs({ username, password, webUrl, gameExe, savePassword, windowed });
-  }, [hydrated, username, password, webUrl, gameExe, savePassword, windowed]);
+    savePrefs({ username, password, webUrl, gameExe, savePassword, displayMode });
+  }, [hydrated, username, password, webUrl, gameExe, savePassword, displayMode]);
 
   async function handleLaunch(e: FormEvent) {
     e.preventDefault();
@@ -174,7 +194,7 @@ export default function LauncherPage() {
         server: resolvedServer,
         apiUrl: resolvedApiUrl,
         gameExe,
-        windowed,
+        displayMode,
       });
       setStatus("launched");
     } catch (err) {
@@ -286,15 +306,25 @@ export default function LauncherPage() {
               Remember password
             </label>
 
-            <label className="flex items-center gap-2 text-xs text-neutral-500 cursor-pointer select-none">
-              <input
-                type="checkbox"
-                checked={windowed}
-                onChange={(e) => setWindowed(e.target.checked)}
-                className="accent-green-500"
-              />
-              Launch in windowed mode
-            </label>
+            <div className="flex flex-col gap-1">
+              <label
+                htmlFor="displayMode"
+                className="text-xs font-semibold uppercase tracking-widest text-neutral-400"
+              >
+                Display Mode
+              </label>
+              <select
+                id="displayMode"
+                value={displayMode}
+                onChange={(e) => setDisplayMode(e.target.value as DisplayModeValue)}
+                disabled={busy}
+                className="rounded-md border border-neutral-700 bg-neutral-800 px-3 py-2 text-neutral-100 focus:outline-none focus:ring-2 focus:ring-green-500 disabled:opacity-50"
+              >
+                {DISPLAY_MODES.map((m) => (
+                  <option key={m.value} value={m.value}>{m.label}</option>
+                ))}
+              </select>
+            </div>
 
             {/* Advanced settings toggle */}
             <button

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -306,26 +306,6 @@ export default function LauncherPage() {
               Remember password
             </label>
 
-            <div className="flex flex-col gap-1">
-              <label
-                htmlFor="displayMode"
-                className="text-xs font-semibold uppercase tracking-widest text-neutral-400"
-              >
-                Display Mode
-              </label>
-              <select
-                id="displayMode"
-                value={displayMode}
-                onChange={(e) => setDisplayMode(e.target.value as DisplayModeValue)}
-                disabled={busy}
-                className="rounded-md border border-neutral-700 bg-neutral-800 px-3 py-2 text-neutral-100 focus:outline-none focus:ring-2 focus:ring-green-500 disabled:opacity-50"
-              >
-                {DISPLAY_MODES.map((m) => (
-                  <option key={m.value} value={m.value}>{m.label}</option>
-                ))}
-              </select>
-            </div>
-
             {/* Advanced settings toggle */}
             <button
               type="button"
@@ -337,6 +317,25 @@ export default function LauncherPage() {
 
             {advanced && (
               <div className="flex flex-col gap-4 border-t border-neutral-800 pt-4">
+                <div className="flex flex-col gap-1">
+                  <label
+                    htmlFor="displayMode"
+                    className="text-xs font-semibold uppercase tracking-widest text-neutral-400"
+                  >
+                    Display Mode
+                  </label>
+                  <select
+                    id="displayMode"
+                    value={displayMode}
+                    onChange={(e) => setDisplayMode(e.target.value as DisplayModeValue)}
+                    disabled={busy}
+                    className="rounded-md border border-neutral-700 bg-neutral-800 px-3 py-2 text-neutral-100 focus:outline-none focus:ring-2 focus:ring-green-500 disabled:opacity-50"
+                  >
+                    {DISPLAY_MODES.map((m) => (
+                      <option key={m.value} value={m.value}>{m.label}</option>
+                    ))}
+                  </select>
+                </div>
                 <Field
                   label="Web URL"
                   id="webUrl"


### PR DESCRIPTION
Replace the windowed-mode checkbox with a **Display Mode** dropdown offering six choices:\n\n- **Fullscreen (640×480 native)** — hardware DirectDraw, no shim\n- **Windowed 640×480** — shim, 1:1 pixel, native size window\n- **Windowed 1024×768** — shim, scaled up (4:3, no letterbox)\n- **Windowed 1280×960** — shim, ~2× integer scale (4:3, no letterbox)\n- **Windowed 1920×1080** — shim, scaled to 1080p with letterboxing\n- **Windowed Fullscreen** — borderless window at monitor resolution, letterboxed\n\n## How it works\n\n**Frontend (page.tsx)**\n- \`windowed: boolean\` replaced by \`displayMode: DisplayModeValue\`\n- Old prefs migrated (windowed=true → window-640x480)\n- \`<select>\` dropdown replaces the checkbox\n\n**Backend (Rust)**\n- \`launch_game\` now takes \`display_mode: String\`\n- Writes \`ddraw.ini\` alongside \`ddraw.dll\` before launch; removes both for fullscreen mode\n- \`cleanup_ddraw\` also removes \`ddraw.ini\` on startup\n\n**DLL (ddraw.cpp)**\n- \`ReadConfig()\` parses \`ddraw.ini\` at \`DLL_PROCESS_ATTACH\`; sets \`g_targetW/H\` and \`g_borderlessFullscreen\`\n- New \`RenderToHDC()\` helper: aspect-correct \`StretchBlt\` with black letterbox bars, plain \`BitBlt\` when no scaling needed\n- \`SetCooperativeLevel\`: sizes window to target dimensions; borderless \`HWND_TOPMOST\` for fullscreen-window mode\n- \`SetDisplayMode\`: skips window resize when a target size is already configured