### PR TITLE
fix(launcher): cap all display modes at 60 FPS

### DIFF
--- a/native/ddraw.cpp
+++ b/native/ddraw.cpp
@@ -111,12 +111,55 @@ static HWND    g_hwnd  = nullptr;
 static int     g_dispW = 640;
 static int     g_dispH = 480;
 static int     g_bpp   = 8;
+static int     g_fpsLimit = 0;
 
 // Target window dimensions read from ddraw.ini (0 = use game resolution)
 static int     g_targetW = 0;
 static int     g_targetH = 0;
 // True when the window should cover the full monitor without chrome
 static bool    g_borderlessFullscreen = false;
+// True when the shim should switch the desktop to the requested game mode and
+// present through a fullscreen popup window.
+static bool    g_nativeFullscreen = false;
+static bool    g_changedDisplayMode = false;
+
+static void RestoreNativeDisplayMode() {
+    if (!g_changedDisplayMode) return;
+    ChangeDisplaySettingsA(nullptr, 0);
+    g_changedDisplayMode = false;
+}
+
+static void EnterNativeDisplayMode() {
+    if (!g_nativeFullscreen || g_changedDisplayMode) return;
+
+    DEVMODEA dm = {};
+    dm.dmSize = sizeof(dm);
+    dm.dmPelsWidth = (DWORD)g_dispW;
+    dm.dmPelsHeight = (DWORD)g_dispH;
+    dm.dmBitsPerPel = 32;
+    dm.dmDisplayFrequency = 60;
+    dm.dmFields = DM_PELSWIDTH | DM_PELSHEIGHT | DM_BITSPERPEL | DM_DISPLAYFREQUENCY;
+
+    LONG result = ChangeDisplaySettingsA(&dm, CDS_FULLSCREEN);
+    if (result != DISP_CHANGE_SUCCESSFUL) {
+        dm.dmFields = DM_PELSWIDTH | DM_PELSHEIGHT | DM_BITSPERPEL;
+        result = ChangeDisplaySettingsA(&dm, CDS_FULLSCREEN);
+    }
+    if (result != DISP_CHANGE_SUCCESSFUL) {
+        dm.dmFields = DM_PELSWIDTH | DM_PELSHEIGHT;
+        result = ChangeDisplaySettingsA(&dm, CDS_FULLSCREEN);
+    }
+
+    if (result == DISP_CHANGE_SUCCESSFUL) {
+        g_changedDisplayMode = true;
+        g_targetW = GetSystemMetrics(SM_CXSCREEN);
+        g_targetH = GetSystemMetrics(SM_CYSCREEN);
+        DbLog("EnterNativeDisplayMode: %dx%d fps_limit=%d", g_targetW, g_targetH, g_fpsLimit);
+    } else {
+        g_nativeFullscreen = false;
+        DbLog("EnterNativeDisplayMode failed: result=%ld; falling back to current desktop mode", result);
+    }
+}
 
 // Shared back-buffer DIB (primary + back surface both refer here)
 static DibBuf  g_backDib;
@@ -144,12 +187,22 @@ static void ReadConfig() {
     cfgPath[sizeof(cfgPath) - 1] = '\0';
 
     char modeBuf[64] = {};
+    char fpsBuf[32] = {};
     GetPrivateProfileStringA("display", "mode", "", modeBuf, sizeof(modeBuf), cfgPath);
+    GetPrivateProfileStringA("display", "fps_limit", "0", fpsBuf, sizeof(fpsBuf), cfgPath);
+    g_fpsLimit = atoi(fpsBuf);
+    if (_stricmp(modeBuf, "fullscreen-native") == 0) {
+        g_nativeFullscreen = true;
+        g_targetW = GetSystemMetrics(SM_CXSCREEN);
+        g_targetH = GetSystemMetrics(SM_CYSCREEN);
+        DbLog("ReadConfig: fullscreen-native %dx%d fps_limit=%d", g_targetW, g_targetH, g_fpsLimit);
+        return;
+    }
     if (_stricmp(modeBuf, "fullscreen-window") == 0) {
         g_borderlessFullscreen = true;
         g_targetW = GetSystemMetrics(SM_CXSCREEN);
         g_targetH = GetSystemMetrics(SM_CYSCREEN);
-        DbLog("ReadConfig: fullscreen-window %dx%d", g_targetW, g_targetH);
+        DbLog("ReadConfig: fullscreen-window %dx%d fps_limit=%d", g_targetW, g_targetH, g_fpsLimit);
         return;
     }
 
@@ -159,9 +212,53 @@ static void ReadConfig() {
     g_targetW = atoi(wBuf);
     g_targetH = atoi(hBuf);
     if (g_targetW > 0 && g_targetH > 0)
-        DbLog("ReadConfig: windowed %dx%d", g_targetW, g_targetH);
+        DbLog("ReadConfig: windowed %dx%d fps_limit=%d", g_targetW, g_targetH, g_fpsLimit);
     else
-        DbLog("ReadConfig: no scaling (game resolution)");
+        DbLog("ReadConfig: no scaling (game resolution) fps_limit=%d", g_fpsLimit);
+}
+
+static bool ShouldPresentNow() {
+    if (g_fpsLimit <= 0) return true;
+
+    static LARGE_INTEGER s_freq = {};
+    static LARGE_INTEGER s_lastPresent = {};
+    static bool s_ready = false;
+
+    if (!s_ready) {
+        if (!QueryPerformanceFrequency(&s_freq) || s_freq.QuadPart <= 0) {
+            return true;
+        }
+        QueryPerformanceCounter(&s_lastPresent);
+        s_ready = true;
+        return true;
+    }
+
+    LARGE_INTEGER now;
+    QueryPerformanceCounter(&now);
+
+    const LONGLONG frameInterval =
+        (s_freq.QuadPart + (g_fpsLimit / 2)) / g_fpsLimit;
+    const LONGLONG burstThreshold =
+        (s_freq.QuadPart + 499) / 500; // about 2 ms
+
+    LONGLONG elapsed = now.QuadPart - s_lastPresent.QuadPart;
+    if (elapsed >= 0 && elapsed < burstThreshold) {
+        return false;
+    }
+
+    if (elapsed >= 0 && elapsed < frameInterval) {
+        DWORD sleepMs = (DWORD)(((frameInterval - elapsed) * 1000) / s_freq.QuadPart);
+        if (sleepMs > 1) {
+            Sleep(sleepMs - 1);
+        }
+        do {
+            QueryPerformanceCounter(&now);
+            elapsed = now.QuadPart - s_lastPresent.QuadPart;
+        } while (elapsed < frameInterval);
+    }
+
+    s_lastPresent = now;
+    return true;
 }
 
 // ============================================================================
@@ -253,6 +350,7 @@ static LPARAM RemapMouseCoord(LPARAM lp) {
 
 static void BlitToWindow() {
     if (!g_hwnd || !g_backDib.hdc) return;
+    if (!ShouldPresentNow()) return;
     static int s_btwCount = 0;
     ++s_btwCount;
     if (s_btwCount % 50 == 0) {
@@ -315,6 +413,7 @@ static LRESULT CALLBACK ShimWndProc(HWND hwnd, UINT msg, WPARAM wp, LPARAM lp) {
     // WM_DESTROY: force the game's quit flag so the WinMain loop exits.
     if (msg == WM_DESTROY) {
         DbLog("WM_DESTROY: setting game quit flag");
+        RestoreNativeDisplayMode();
         *GAME_FLAGS_ADDR |= GAME_FLAGS_ADDR_QUIT_BIT;
     }
     return CallWindowProcA(g_origWndProc, hwnd, msg, wp, lp);
@@ -810,11 +909,15 @@ public:
         DbLog("SetCooperativeLevel hwnd=0x%p", (void*)hwnd);
         g_hwnd = hwnd;
 
+        if (g_nativeFullscreen) {
+            EnterNativeDisplayMode();
+        }
+
         int wndW = (g_targetW > 0) ? g_targetW : g_dispW;
         int wndH = (g_targetH > 0) ? g_targetH : g_dispH;
 
-        if (g_borderlessFullscreen) {
-            // Borderless fullscreen: no title bar, no chrome, covers the whole monitor
+        if (g_borderlessFullscreen || g_nativeFullscreen) {
+            // Fullscreen shim modes: no title bar, no chrome, cover the monitor.
             LONG style = GetWindowLongA(hwnd, GWL_STYLE);
             style &= ~(WS_CAPTION | WS_SYSMENU | WS_MINIMIZEBOX | WS_THICKFRAME | WS_DLGFRAME);
             style |= WS_POPUP;
@@ -861,6 +964,10 @@ public:
     HRESULT STDMETHODCALLTYPE SetDisplayMode(DWORD w, DWORD h, DWORD bpp) override {
         DbLog("SetDisplayMode %dx%dx%d", (int)w, (int)h, (int)bpp);
         g_dispW = (int)w; g_dispH = (int)h; g_bpp = (int)bpp;
+
+        if (g_nativeFullscreen) {
+            EnterNativeDisplayMode();
+        }
 
         // Only resize the window when no target scaling is configured;
         // SetCooperativeLevel already set the window to the target size.
@@ -980,6 +1087,8 @@ BOOL WINAPI DllMain(HINSTANCE, DWORD fdwReason, LPVOID)
         // Config is loaded lazily on the first DirectDrawCreate call.
         DbLog("ddraw_shim loaded");
         PatchGameIAT();
+    } else if (fdwReason == DLL_PROCESS_DETACH) {
+        RestoreNativeDisplayMode();
     }
     return TRUE;
 }

--- a/native/ddraw.cpp
+++ b/native/ddraw.cpp
@@ -26,6 +26,8 @@
 // initguid.h causes GUIDs to be defined inline (no dxguid.lib required)
 #include <initguid.h>
 #include <ddraw.h>
+#include <cerrno>
+#include <cstdlib>
 #include <cstring>
 #include <cstdio>
 #include <cstdarg>
@@ -129,6 +131,23 @@ static void RestoreNativeDisplayMode() {
     g_changedDisplayMode = false;
 }
 
+static int ParseFpsLimit(const char* text) {
+    if (!text) return 0;
+
+    while (*text == ' ' || *text == '\t') ++text;
+    if (*text == '\0') return 0;
+
+    errno = 0;
+    char* end = nullptr;
+    long parsed = strtol(text, &end, 10);
+    while (*end == ' ' || *end == '\t') ++end;
+
+    if (text == end || *end != '\0' || errno == ERANGE || parsed < 1 || parsed > 240) {
+        return 0;
+    }
+    return (int)parsed;
+}
+
 static void EnterNativeDisplayMode() {
     if (!g_nativeFullscreen || g_changedDisplayMode) return;
 
@@ -190,7 +209,7 @@ static void ReadConfig() {
     char fpsBuf[32] = {};
     GetPrivateProfileStringA("display", "mode", "", modeBuf, sizeof(modeBuf), cfgPath);
     GetPrivateProfileStringA("display", "fps_limit", "0", fpsBuf, sizeof(fpsBuf), cfgPath);
-    g_fpsLimit = atoi(fpsBuf);
+    g_fpsLimit = ParseFpsLimit(fpsBuf);
     if (_stricmp(modeBuf, "fullscreen-native") == 0) {
         g_nativeFullscreen = true;
         g_targetW = GetSystemMetrics(SM_CXSCREEN);
@@ -1087,8 +1106,6 @@ BOOL WINAPI DllMain(HINSTANCE, DWORD fdwReason, LPVOID)
         // Config is loaded lazily on the first DirectDrawCreate call.
         DbLog("ddraw_shim loaded");
         PatchGameIAT();
-    } else if (fdwReason == DLL_PROCESS_DETACH) {
-        RestoreNativeDisplayMode();
     }
     return TRUE;
 }

--- a/src-tauri/src/game.rs
+++ b/src-tauri/src/game.rs
@@ -1,19 +1,18 @@
-/// game.rs — Game launch with optional DirectDraw windowed shim + multi-instance patch
+/// game.rs — Game launch with DirectDraw shim deployment + multi-instance patch
 ///
-/// When `windowed` is true:
-///   • The ddraw.dll shim is written into the game directory so the game runs
-///     in a window (Windows DLL search order picks it up before system ddraw).
-///   • A permanently-patched copy of the EXE (`<stem>_windowed.exe`) is created
-///     once alongside the original.  Two patches are applied to the copy:
-///     (a) the single-instance guard (JZ → JMP, one byte) so multiple
-///         simultaneous instances are allowed, and (b) the self-integrity CRC
-///         check bypass, because patching (a) changes the file's CRC which
-///         would otherwise cause a "Fatal startup error" on launch.
-///     The original is never modified.
-///   • The patched copy is what gets launched.
+/// All launcher-managed display modes deploy `ddraw.dll` and write a matching
+/// `ddraw.ini` next to the game EXE so the launcher owns scaling and pacing.
 ///
-/// When `windowed` is false the ddraw shim is removed and the original
-/// unpatched EXE is launched as normal.
+/// For the dedicated `fullscreen` option we keep the stock EXE path, but still
+/// configure the shim for native fullscreen handling.
+///
+/// All other display modes use a permanently-patched copy of the EXE
+/// (`<stem>_windowed.exe`) created once alongside the original. Two patches are
+/// applied to the copy:
+///   • the single-instance guard (JZ → JMP, one byte) so multiple simultaneous
+///     instances are allowed
+///   • the self-integrity CRC check bypass, because patching the guard changes
+///     the file's CRC and would otherwise cause a startup failure
 ///
 /// Using a separate file avoids trying to write to an EXE that Windows has
 /// memory-mapped as a running process (which would fail with a sharing
@@ -124,29 +123,29 @@ fn windowed_exe(original: &std::path::Path) -> Result<std::path::PathBuf, String
 
 /// Return the `[display]` section content for `ddraw.ini` given a display mode
 /// string.
-fn ddraw_ini_content(display_mode: &str) -> Option<String> {
-    const WINDOWED_FPS_LIMIT: u32 = 60;
+fn ddraw_ini_content(display_mode: &str) -> String {
+    const FPS_LIMIT: u32 = 60;
 
     match display_mode {
-        "fullscreen" => Some(format!(
-            "[display]\nmode=fullscreen-native\nfps_limit={WINDOWED_FPS_LIMIT}\n"
-        )),
-        "window-fullscreen" => Some(format!(
-            "[display]\nmode=fullscreen-window\nfps_limit={WINDOWED_FPS_LIMIT}\n"
-        )),
+        "fullscreen" => {
+            format!("[display]\nmode=fullscreen-native\nfps_limit={FPS_LIMIT}\n")
+        }
+        "window-fullscreen" => {
+            format!("[display]\nmode=fullscreen-window\nfps_limit={FPS_LIMIT}\n")
+        }
         other => {
             // Expect "window-WxH" e.g. "window-1920x1080"
             if let Some(size) = other.strip_prefix("window-") {
                 if let Some((w, h)) = size.split_once('x') {
                     if let (Ok(w), Ok(h)) = (w.parse::<u32>(), h.parse::<u32>()) {
-                        return Some(format!(
-                            "[display]\nwidth={w}\nheight={h}\nfps_limit={WINDOWED_FPS_LIMIT}\n"
-                        ));
+                        return format!(
+                            "[display]\nwidth={w}\nheight={h}\nfps_limit={FPS_LIMIT}\n"
+                        );
                     }
                 }
             }
             // Unknown or malformed windowed mode — use plain windowed at game resolution
-            Some(format!("[display]\nfps_limit={WINDOWED_FPS_LIMIT}\n"))
+            format!("[display]\nfps_limit={FPS_LIMIT}\n")
         }
     }
 }
@@ -163,42 +162,29 @@ pub fn launch_game(
     let dest_ddraw = game_dir.join("ddraw.dll");
     let dest_ini = game_dir.join("ddraw.ini");
 
-    let exe_to_launch: std::path::PathBuf;
+    // All launcher display modes now go through the shim so the launcher can
+    // own display behavior and the 60 FPS pacing fix consistently.
+    let ini_content = ddraw_ini_content(display_mode);
 
-    if let Some(ini_content) = ddraw_ini_content(display_mode) {
-        // All launcher display modes now go through the shim so the launcher can
-        // own display behavior and the 60 FPS pacing fix consistently.
+    // Write ddraw.ini (mode/resolution config for the shim).
+    std::fs::write(&dest_ini, &ini_content).map_err(|e| format!("Failed to write ddraw.ini: {e}"))?;
 
-        // Write ddraw.ini (mode/resolution config for the shim).
-        std::fs::write(&dest_ini, &ini_content)
-            .map_err(|e| format!("Failed to write ddraw.ini: {e}"))?;
-
-        // Write the ddraw shim.  Sharing violation is non-fatal — another
-        // instance already placed it.
-        if let Err(e) = std::fs::write(&dest_ddraw, DDRAW_DLL_BYTES) {
-            if e.raw_os_error() != Some(ERROR_SHARING_VIOLATION) {
-                return Err(format!("Failed to write ddraw.dll to game dir: {e}"));
-            }
+    // Write the ddraw shim. Sharing violation is non-fatal — another instance
+    // already placed it.
+    if let Err(e) = std::fs::write(&dest_ddraw, DDRAW_DLL_BYTES) {
+        if e.raw_os_error() != Some(ERROR_SHARING_VIOLATION) {
+            return Err(format!("Failed to write ddraw.dll to game dir: {e}"));
         }
-
-        if display_mode == "fullscreen" {
-            // Keep the stock EXE name/launch path for native fullscreen mode.
-            exe_to_launch = game_exe.to_path_buf();
-        } else {
-            // Use the patched copy for shim-managed windowed modes so we never
-            // touch a running EXE and still allow multi-instance launches.
-            exe_to_launch = windowed_exe(game_exe)?;
-        }
-    } else {
-        // Full-screen mode: remove the ddraw shim and config, use original EXE.
-        if dest_ddraw.exists() {
-            let _ = std::fs::remove_file(&dest_ddraw);
-        }
-        if dest_ini.exists() {
-            let _ = std::fs::remove_file(&dest_ini);
-        }
-        exe_to_launch = game_exe.to_path_buf();
     }
+
+    let exe_to_launch = if display_mode == "fullscreen" {
+        // Keep the stock EXE name/launch path for native fullscreen mode.
+        game_exe.to_path_buf()
+    } else {
+        // Use the patched copy for shim-managed windowed modes so we never
+        // touch a running EXE and still allow multi-instance launches.
+        windowed_exe(game_exe)?
+    };
 
     std::process::Command::new(&exe_to_launch)
         .arg(pcgi_path)

--- a/src-tauri/src/game.rs
+++ b/src-tauri/src/game.rs
@@ -49,23 +49,25 @@ fn windowed_exe(original: &std::path::Path) -> Result<std::path::PathBuf, String
         .file_stem()
         .ok_or("game_exe has no file stem")?
         .to_string_lossy();
-    let patched = original
-        .with_file_name(format!("{stem}_windowed.exe"));
+    let patched = original.with_file_name(format!("{stem}_windowed.exe"));
 
     const PATCH_IDX: usize = 2;
-    const BYTE_JZ:   u8    = 0x74;
-    const BYTE_JMP:  u8    = 0xEB;
+    const BYTE_JZ: u8 = 0x74;
+    const BYTE_JMP: u8 = 0xEB;
 
-    let mut data = std::fs::read(original)
-        .map_err(|e| format!("Failed to read game EXE: {e}"))?;
+    let mut data = std::fs::read(original).map_err(|e| format!("Failed to read game EXE: {e}"))?;
 
     // Patch 1: single-instance guard (JZ → JMP).
     // Pattern: TEST EAX,EAX; Jcc +0x15; PUSH 1; PUSH EAX
     //          85 C0 [74|EB] 15 6A 01 50
     let found = data.windows(7).enumerate().find(|(_, w)| {
-        w[0] == 0x85 && w[1] == 0xC0
+        w[0] == 0x85
+            && w[1] == 0xC0
             && (w[PATCH_IDX] == BYTE_JZ || w[PATCH_IDX] == BYTE_JMP)
-            && w[3] == 0x15 && w[4] == 0x6A && w[5] == 0x01 && w[6] == 0x50
+            && w[3] == 0x15
+            && w[4] == 0x6A
+            && w[5] == 0x01
+            && w[6] == 0x50
     });
     if let Some((offset, _)) = found {
         data[offset + PATCH_IDX] = BYTE_JMP;
@@ -82,14 +84,21 @@ fn windowed_exe(original: &std::path::Path) -> Result<std::path::PathBuf, String
     // We replace the whole sequence with: MOV EAX,1; NOP×5; RET
     // SBB EAX,EAX is encoded as 0x19 0xC0 (v1.06) or 0x1B 0xC0 (v1.23).
     const CRC_PATTERNS: [[u8; 11]; 2] = [
-        [0x83, 0xE8, 0x0A, 0x83, 0xF8, 0x01, 0x19, 0xC0, 0xF7, 0xD8, 0xC3],
-        [0x83, 0xE8, 0x0A, 0x83, 0xF8, 0x01, 0x1B, 0xC0, 0xF7, 0xD8, 0xC3],
+        [
+            0x83, 0xE8, 0x0A, 0x83, 0xF8, 0x01, 0x19, 0xC0, 0xF7, 0xD8, 0xC3,
+        ],
+        [
+            0x83, 0xE8, 0x0A, 0x83, 0xF8, 0x01, 0x1B, 0xC0, 0xF7, 0xD8, 0xC3,
+        ],
     ];
-    const CRC_PATCH:   [u8; 11] = [0xB8, 0x01, 0x00, 0x00, 0x00, 0x90,
-                                    0x90, 0x90, 0x90, 0x90, 0xC3];
-    if let Some((off, _)) = data.windows(11).enumerate().find(|(_, w)| {
-        CRC_PATTERNS.iter().any(|p| w == p)
-    }) {
+    const CRC_PATCH: [u8; 11] = [
+        0xB8, 0x01, 0x00, 0x00, 0x00, 0x90, 0x90, 0x90, 0x90, 0x90, 0xC3,
+    ];
+    if let Some((off, _)) = data
+        .windows(11)
+        .enumerate()
+        .find(|(_, w)| CRC_PATTERNS.iter().any(|p| w == p))
+    {
         data[off..off + 11].copy_from_slice(&CRC_PATCH);
     }
 
@@ -97,10 +106,16 @@ fn windowed_exe(original: &std::path::Path) -> Result<std::path::PathBuf, String
     // If another launcher got here first, AlreadyExists means the copy is ready
     // and we can use it as-is.
     use std::io::Write as _;
-    match std::fs::OpenOptions::new().write(true).create_new(true).open(&patched) {
-        Ok(mut f) => f.write_all(&data)
+    match std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&patched)
+    {
+        Ok(mut f) => f
+            .write_all(&data)
             .map_err(|e| format!("Failed to write windowed EXE copy: {e}"))?,
-        Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => { /* another process created it */ }
+        Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => { /* another process created it */
+        }
         Err(e) => return Err(format!("Failed to create windowed EXE copy: {e}")),
     }
 
@@ -108,22 +123,30 @@ fn windowed_exe(original: &std::path::Path) -> Result<std::path::PathBuf, String
 }
 
 /// Return the `[display]` section content for `ddraw.ini` given a display mode
-/// string, or `None` if the mode is "fullscreen" (no shim needed).
+/// string.
 fn ddraw_ini_content(display_mode: &str) -> Option<String> {
+    const WINDOWED_FPS_LIMIT: u32 = 60;
+
     match display_mode {
-        "fullscreen" => None,
-        "window-fullscreen" => Some("[display]\nmode=fullscreen-window\n".into()),
+        "fullscreen" => Some(format!(
+            "[display]\nmode=fullscreen-native\nfps_limit={WINDOWED_FPS_LIMIT}\n"
+        )),
+        "window-fullscreen" => Some(format!(
+            "[display]\nmode=fullscreen-window\nfps_limit={WINDOWED_FPS_LIMIT}\n"
+        )),
         other => {
             // Expect "window-WxH" e.g. "window-1920x1080"
             if let Some(size) = other.strip_prefix("window-") {
                 if let Some((w, h)) = size.split_once('x') {
                     if let (Ok(w), Ok(h)) = (w.parse::<u32>(), h.parse::<u32>()) {
-                        return Some(format!("[display]\nwidth={}\nheight={}\n", w, h));
+                        return Some(format!(
+                            "[display]\nwidth={w}\nheight={h}\nfps_limit={WINDOWED_FPS_LIMIT}\n"
+                        ));
                     }
                 }
             }
             // Unknown or malformed windowed mode — use plain windowed at game resolution
-            Some("[display]\n".into())
+            Some(format!("[display]\nfps_limit={WINDOWED_FPS_LIMIT}\n"))
         }
     }
 }
@@ -134,14 +157,17 @@ pub fn launch_game(
     display_mode: &str,
     pcgi_path: &std::path::Path,
 ) -> Result<(), String> {
-    let game_dir = game_exe.parent().ok_or("game_exe has no parent directory")?;
+    let game_dir = game_exe
+        .parent()
+        .ok_or("game_exe has no parent directory")?;
     let dest_ddraw = game_dir.join("ddraw.dll");
-    let dest_ini   = game_dir.join("ddraw.ini");
+    let dest_ini = game_dir.join("ddraw.ini");
 
     let exe_to_launch: std::path::PathBuf;
 
     if let Some(ini_content) = ddraw_ini_content(display_mode) {
-        // Windowed mode: write config, deploy shim, use patched EXE.
+        // All launcher display modes now go through the shim so the launcher can
+        // own display behavior and the 60 FPS pacing fix consistently.
 
         // Write ddraw.ini (mode/resolution config for the shim).
         std::fs::write(&dest_ini, &ini_content)
@@ -155,12 +181,22 @@ pub fn launch_game(
             }
         }
 
-        // Use the patched copy so we never touch a running EXE.
-        exe_to_launch = windowed_exe(game_exe)?;
+        if display_mode == "fullscreen" {
+            // Keep the stock EXE name/launch path for native fullscreen mode.
+            exe_to_launch = game_exe.to_path_buf();
+        } else {
+            // Use the patched copy for shim-managed windowed modes so we never
+            // touch a running EXE and still allow multi-instance launches.
+            exe_to_launch = windowed_exe(game_exe)?;
+        }
     } else {
         // Full-screen mode: remove the ddraw shim and config, use original EXE.
-        if dest_ddraw.exists() { let _ = std::fs::remove_file(&dest_ddraw); }
-        if dest_ini.exists()   { let _ = std::fs::remove_file(&dest_ini); }
+        if dest_ddraw.exists() {
+            let _ = std::fs::remove_file(&dest_ddraw);
+        }
+        if dest_ini.exists() {
+            let _ = std::fs::remove_file(&dest_ini);
+        }
         exe_to_launch = game_exe.to_path_buf();
     }
 
@@ -181,4 +217,3 @@ pub fn launch_game(
 ) -> Result<(), String> {
     Err("MPBT only runs on Windows".to_string())
 }
-

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -13,7 +13,7 @@ interface ClientConfig {
 }
 
 const DISPLAY_MODES = [
-  { value: "fullscreen",        label: "Fullscreen (640×480 native, 60 FPS capped)" },
+  { value: "fullscreen",        label: "Fullscreen (640×480 native)" },
   { value: "window-640x480",    label: "Windowed 640×480" },
   { value: "window-1024x768",   label: "Windowed 1024×768" },
   { value: "window-1280x960",   label: "Windowed 1280×960" },
@@ -335,6 +335,9 @@ export default function LauncherPage() {
                       <option key={m.value} value={m.value}>{m.label}</option>
                     ))}
                   </select>
+                  <p className="text-xs text-neutral-500">
+                    All display modes are capped at 60 FPS.
+                  </p>
                 </div>
                 <Field
                   label="Web URL"

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -13,7 +13,7 @@ interface ClientConfig {
 }
 
 const DISPLAY_MODES = [
-  { value: "fullscreen",        label: "Fullscreen (640×480 native)" },
+  { value: "fullscreen",        label: "Fullscreen (640×480 native, 60 FPS capped)" },
   { value: "window-640x480",    label: "Windowed 640×480" },
   { value: "window-1024x768",   label: "Windowed 1024×768" },
   { value: "window-1280x960",   label: "Windowed 1280×960" },


### PR DESCRIPTION
## Summary
Fixes #11.

- route the dedicated `fullscreen` option through a new `fullscreen-native` shim mode
- write `fps_limit=60` for every launcher display mode
- apply the shared present pacing in native fullscreen and restore the desktop display mode on exit
- update the display-mode UI copy so the launcher notes that all display modes are capped at 60 FPS

## Validation
- `npm run build:ddraw`
- `cargo check --manifest-path src-tauri\Cargo.toml`
- `npm run build`
- code-path verification that all six display modes now write `fps_limit=60` and pass through the shared pacing path

## Notes
- keeps the stock EXE launch path for dedicated fullscreen while still using the launcher-managed `ddraw.ini` and shim flow
- leaves the existing `window-*` and `window-fullscreen` behavior intact aside from the shared 60 FPS pacing path
