### PR TITLE
fix: harden v1.29 launcher path

### DIFF
--- a/native/build.bat
+++ b/native/build.bat
@@ -23,11 +23,14 @@ if not exist %VCVARS% (
     exit /b 1
 )
 
-:: If cl.exe is already on PATH (e.g. set up by the CI ilammy/msvc-dev-cmd
-:: action) skip vcvarsall to avoid the VsDevCmd "already initialized" error.
+:: Only skip vcvarsall when both cl.exe and the MSVC include/lib environment
+:: are already present. Some shells expose cl.exe on PATH without INCLUDE/LIB,
+:: which still makes windows.h resolution fail.
 where cl.exe >nul 2>&1
-if %ERRORLEVEL% == 0 goto :build
+if %ERRORLEVEL% neq 0 goto :init_env
+if not "%INCLUDE%"=="" if not "%LIB%"=="" goto :build
 
+:init_env
 call %VCVARS% x86
 
 :build

--- a/native/ddraw.cpp
+++ b/native/ddraw.cpp
@@ -101,8 +101,20 @@ static void DbLog(const char* fmt, ...) {
     OutputDebugStringA("[ddraw_shim] ");
     OutputDebugStringA(buf);
     OutputDebugStringA("\n");
-    FILE* f = fopen("C:\\MPBT\\ddraw_shim.log", "a+");
-    if (f) { fputs(buf, f); fputc('\n', f); fclose(f); }
+    HANDLE logFile = CreateFileA(
+        "C:\\MPBT\\ddraw_shim.log",
+        FILE_APPEND_DATA,
+        FILE_SHARE_READ | FILE_SHARE_WRITE,
+        nullptr,
+        OPEN_ALWAYS,
+        FILE_ATTRIBUTE_NORMAL,
+        nullptr);
+    if (logFile != INVALID_HANDLE_VALUE) {
+        DWORD written = 0;
+        WriteFile(logFile, buf, (DWORD)strlen(buf), &written, nullptr);
+        WriteFile(logFile, "\r\n", 2, &written, nullptr);
+        CloseHandle(logFile);
+    }
 }
 
 // ============================================================================
@@ -361,27 +373,22 @@ static LPARAM RemapMouseCoord(LPARAM lp) {
     return MAKELPARAM(gx, gy);
 }
 
-// Known addresses inside MPBTWIN.EXE (.data segment, image base 0x00400000)
-#define GAME_FLAGS_ADDR    ((volatile DWORD*)0x0047a7c8)  // bit0=render enabled, bit1=quit
-#define GAME_STATE_ADDR    ((volatile DWORD*)0x0047d05c)  // 0-2=no render, 3=lobby, 4=battle
-#define GAME_GUARD_ADDR    ((volatile DWORD*)0x0047ef60)  // state-4 guard (bit0 must be 1)
-#define GAME_SPRITES_ADDR  ((volatile DWORD*)0x004f669c)  // active sprite count (state 3)
-
 static void BlitToWindow() {
     if (!g_hwnd || !g_backDib.hdc) return;
     if (!ShouldPresentNow()) return;
     static int s_btwCount = 0;
     ++s_btwCount;
     if (s_btwCount % 50 == 0) {
-        DWORD flags   = *GAME_FLAGS_ADDR;
-        DWORD state   = *GAME_STATE_ADDR;
-        DWORD guard   = *GAME_GUARD_ADDR;
-        DWORD sprites = *GAME_SPRITES_ADDR;
         BYTE  cpx = 0;
         if (g_backDib.bits && g_backDib.w > 1 && g_backDib.h > 1)
             cpx = ((BYTE*)g_backDib.bits)[(g_backDib.h/2)*g_backDib.pitch + g_backDib.w/2];
-        DbLog("BTW #%d  state=%d flags=0x%08x guard=0x%x sprites=%d prim_center=0x%02x",
-              s_btwCount, (int)state, (unsigned)flags, (unsigned)guard, (int)sprites, (unsigned)cpx);
+        DbLog("BTW #%d prim_center=0x%02x back=%dx%d target=%dx%d",
+              s_btwCount,
+              (unsigned)cpx,
+              g_backDib.w,
+              g_backDib.h,
+              (g_targetW > 0) ? g_targetW : g_backDib.w,
+              (g_targetH > 0) ? g_targetH : g_backDib.h);
     }
     int winW = (g_targetW > 0) ? g_targetW : g_backDib.w;
     int winH = (g_targetH > 0) ? g_targetH : g_backDib.h;
@@ -389,9 +396,6 @@ static void BlitToWindow() {
     RenderToHDC(wdc, winW, winH);
     ReleaseDC(g_hwnd, wdc);
 }
-
-// Bit 1 of the flags word is the WinMain quit flag.
-#define GAME_FLAGS_ADDR_QUIT_BIT 0x02
 
 // Subclass WndProc: handle WM_PAINT from our DIB; remap mouse coords when
 // scaling is active; suppress WM_ACTIVATEAPP deactivation so the game's
@@ -429,11 +433,11 @@ static LRESULT CALLBACK ShimWndProc(HWND hwnd, UINT msg, WPARAM wp, LPARAM lp) {
         DbLog("WM_ACTIVATE(WA_INACTIVE) suppressed -> WA_ACTIVE");
         wp = (wp & 0xFFFF0000) | WA_ACTIVE;
     }
-    // WM_DESTROY: force the game's quit flag so the WinMain loop exits.
+    // WM_DESTROY: restore the desktop mode and post WM_QUIT for the game loop.
     if (msg == WM_DESTROY) {
-        DbLog("WM_DESTROY: setting game quit flag");
+        DbLog("WM_DESTROY");
         RestoreNativeDisplayMode();
-        *GAME_FLAGS_ADDR |= GAME_FLAGS_ADDR_QUIT_BIT;
+        PostQuitMessage(0);
     }
     return CallWindowProcA(g_origWndProc, hwnd, msg, wp, lp);
 }
@@ -650,23 +654,12 @@ public:
             // Always log when src surface changes, first 10 total, and every 200th.
             bool newSrc = (src != s_lastSrc);
             if (newSrc || s_bltCount <= 10 || s_bltCount % 200 == 0) {
-                // Also dump game-internal buffer addresses for diagnostics
-                DWORD mainCtx  = *(volatile DWORD*)0x0047a378;
-                DWORD pxStruct = mainCtx ? *(volatile DWORD*)(mainCtx + 0x4C) : 0;
-                DWORD bitsA    = pxStruct ? *(volatile DWORD*)pxStruct : 0;
-                DWORD bitsB    = *(volatile DWORD*)0x004da2f0;
-                DWORD surfA    = pxStruct ? *(volatile DWORD*)(pxStruct + 0x14) : 0;
-                DWORD surfB    = *(volatile DWORD*)0x004da2f8;
-                DWORD dispSurf = *(volatile DWORD*)0x0047a7ec;
                 DbLog("Primary Blt #%d src=%p%s dst=(%d,%d %dx%d) center_px=0x%02x "
-                      "nonZero=%d firstNZ@%d=0x%02x bitsA=0x%08x bitsB=0x%08x "
-                      "srcBits=%p surfA=%08x surfB=%08x disp=%08x",
+                      "nonZero=%d firstNZ@%d=0x%02x srcBits=%p",
                       s_bltCount, src, newSrc ? " [NEW]" : "",
                       dx, dy, sw, sh, (unsigned)px,
                       nonZero, firstNZOff, (unsigned)firstNZVal,
-                      (unsigned)bitsA, (unsigned)bitsB,
-                      fs->dib().bits, (unsigned)surfA, (unsigned)surfB,
-                      (unsigned)dispSurf);
+                      fs->dib().bits);
                 s_lastSrc = src;
             }
             BlitToWindow();
@@ -1106,6 +1099,8 @@ BOOL WINAPI DllMain(HINSTANCE, DWORD fdwReason, LPVOID)
         // Config is loaded lazily on the first DirectDrawCreate call.
         DbLog("ddraw_shim loaded");
         PatchGameIAT();
+    } else if (fdwReason == DLL_PROCESS_DETACH) {
+        RestoreNativeDisplayMode();
     }
     return TRUE;
 }

--- a/native/ddraw.cpp
+++ b/native/ddraw.cpp
@@ -1099,8 +1099,6 @@ BOOL WINAPI DllMain(HINSTANCE, DWORD fdwReason, LPVOID)
         // Config is loaded lazily on the first DirectDrawCreate call.
         DbLog("ddraw_shim loaded");
         PatchGameIAT();
-    } else if (fdwReason == DLL_PROCESS_DETACH) {
-        RestoreNativeDisplayMode();
     }
     return TRUE;
 }

--- a/src-tauri/src/game.rs
+++ b/src-tauri/src/game.rs
@@ -61,14 +61,14 @@ fn source_fingerprint(bytes: &[u8]) -> u64 {
 #[cfg(target_os = "windows")]
 fn windowed_exe(original: &std::path::Path) -> Result<std::path::PathBuf, String> {
     let mut data = std::fs::read(original).map_err(|e| format!("Failed to read game EXE: {e}"))?;
-    let source_fingerprint = source_fingerprint(&data);
+    let exe_fingerprint = source_fingerprint(&data);
 
     let stem = original
         .file_stem()
         .ok_or("game_exe has no file stem")?
         .to_string_lossy();
     let patched = original.with_file_name(format!(
-        "{stem}_windowed_{source_fingerprint:016x}.exe"
+        "{stem}_windowed_{exe_fingerprint:016x}.exe"
     ));
 
     const PATCH_IDX: usize = 2;
@@ -116,10 +116,16 @@ fn windowed_exe(original: &std::path::Path) -> Result<std::path::PathBuf, String
     const CRC_PATCH: [u8; 11] = [
         0xB8, 0x01, 0x00, 0x00, 0x00, 0x90, 0x90, 0x90, 0x90, 0x90, 0xC3,
     ];
-    let (crc_offset, _) = data
+    let crc_offset = data
         .windows(11)
         .enumerate()
-        .find(|(_, w)| CRC_PATTERNS.iter().any(|p| w == p))
+        .find_map(|(offset, window)| {
+            if CRC_PATTERNS.iter().any(|pattern| window == pattern) || window == CRC_PATCH {
+                Some(offset)
+            } else {
+                None
+            }
+        })
         .ok_or_else(|| {
             format!(
                 "Unsupported game EXE ({}): CRC bypass signature not found",

--- a/src-tauri/src/game.rs
+++ b/src-tauri/src/game.rs
@@ -6,9 +6,9 @@
 /// For the dedicated `fullscreen` option we keep the stock EXE path, but still
 /// configure the shim for native fullscreen handling.
 ///
-/// All other display modes use a permanently-patched copy of the EXE
-/// (`<stem>_windowed.exe`) created once alongside the original. Two patches are
-/// applied to the copy:
+/// All other display modes use a version-keyed patched copy of the EXE
+/// (`<stem>_windowed_<source-fingerprint>.exe`) created alongside the original.
+/// Two patches are applied to the copy:
 ///   • the single-instance guard (JZ → JMP, one byte) so multiple simultaneous
 ///     instances are allowed
 ///   • the self-integrity CRC check bypass, because patching the guard changes
@@ -32,8 +32,12 @@ const ERROR_SHARING_VIOLATION: i32 = 32;
 
 /// Return the path of the windowed-mode EXE copy, creating it if needed.
 ///
-/// The copy is placed next to the original as `<stem>_windowed.exe`
-/// (e.g. `Mpbtwin.exe` → `Mpbtwin_windowed.exe`).
+/// The copy is placed next to the original as
+/// `<stem>_windowed_<source-fingerprint>.exe`.
+///
+/// Keying the sidecar to the original EXE bytes avoids reusing a stale patched
+/// copy after the client is upgraded in place (for example `v1.23` -> `v1.29`
+/// under the same `C:\MPBT` install path).
 ///
 /// The single-instance guard is a single `JZ` byte (`0x74`) changed to `JMP`
 /// (`0xEB`).  We locate it by scanning for the distinctive surrounding bytes:
@@ -42,19 +46,34 @@ const ERROR_SHARING_VIOLATION: i32 = 32;
 ///   85 C0 [74|EB] 15 6A 01 50
 ///           ^--- patch target (index 2)
 #[cfg(target_os = "windows")]
+fn source_fingerprint(bytes: &[u8]) -> u64 {
+    const FNV_OFFSET: u64 = 0xcbf29ce484222325;
+    const FNV_PRIME: u64 = 0x100000001b3;
+
+    let mut hash = FNV_OFFSET;
+    for byte in bytes {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(FNV_PRIME);
+    }
+    hash
+}
+
+#[cfg(target_os = "windows")]
 fn windowed_exe(original: &std::path::Path) -> Result<std::path::PathBuf, String> {
-    // Build `<stem>_windowed.exe` next to the original.
+    let mut data = std::fs::read(original).map_err(|e| format!("Failed to read game EXE: {e}"))?;
+    let source_fingerprint = source_fingerprint(&data);
+
     let stem = original
         .file_stem()
         .ok_or("game_exe has no file stem")?
         .to_string_lossy();
-    let patched = original.with_file_name(format!("{stem}_windowed.exe"));
+    let patched = original.with_file_name(format!(
+        "{stem}_windowed_{source_fingerprint:016x}.exe"
+    ));
 
     const PATCH_IDX: usize = 2;
     const BYTE_JZ: u8 = 0x74;
     const BYTE_JMP: u8 = 0xEB;
-
-    let mut data = std::fs::read(original).map_err(|e| format!("Failed to read game EXE: {e}"))?;
 
     // Patch 1: single-instance guard (JZ → JMP).
     // Pattern: TEST EAX,EAX; Jcc +0x15; PUSH 1; PUSH EAX
@@ -68,9 +87,13 @@ fn windowed_exe(original: &std::path::Path) -> Result<std::path::PathBuf, String
             && w[5] == 0x01
             && w[6] == 0x50
     });
-    if let Some((offset, _)) = found {
-        data[offset + PATCH_IDX] = BYTE_JMP;
-    }
+    let (single_instance_offset, _) = found.ok_or_else(|| {
+        format!(
+            "Unsupported game EXE ({}): multi-instance signature not found",
+            original.display()
+        )
+    })?;
+    data[single_instance_offset + PATCH_IDX] = BYTE_JMP;
 
     // Patch 2: self-integrity CRC check bypass.
     // The game calls GetModuleFileNameA on itself, computes a CRC, and
@@ -93,13 +116,17 @@ fn windowed_exe(original: &std::path::Path) -> Result<std::path::PathBuf, String
     const CRC_PATCH: [u8; 11] = [
         0xB8, 0x01, 0x00, 0x00, 0x00, 0x90, 0x90, 0x90, 0x90, 0x90, 0xC3,
     ];
-    if let Some((off, _)) = data
+    let (crc_offset, _) = data
         .windows(11)
         .enumerate()
         .find(|(_, w)| CRC_PATTERNS.iter().any(|p| w == p))
-    {
-        data[off..off + 11].copy_from_slice(&CRC_PATCH);
-    }
+        .ok_or_else(|| {
+            format!(
+                "Unsupported game EXE ({}): CRC bypass signature not found",
+                original.display()
+            )
+        })?;
+    data[crc_offset..crc_offset + 11].copy_from_slice(&CRC_PATCH);
 
     // Use create_new (O_CREAT | O_EXCL) so only one process wins the race.
     // If another launcher got here first, AlreadyExists means the copy is ready


### PR DESCRIPTION
## Summary

Harden the launcher''s v1.29 windowed path so it rebuilds the patched sidecar per source EXE, fails explicitly when the patch signatures move, and stops touching version-specific client globals from the DirectDraw shim''s logging path.

## Related Issue

Closes #13

## Type of Change

- [x] Bug fix
- [ ] Feature / enhancement
- [ ] Research finding / protocol update
- [ ] Documentation update
- [ ] Refactor / internal cleanup
- [ ] Chore (dependencies, CI, config)

## Implementation Notes

- key the windowed sidecar EXE name to a fingerprint of the source client so in-place upgrades do not keep reusing an older patched copy
- return explicit launcher errors when the multi-instance or CRC bypass signatures are no longer present in the source EXE
- remove version-specific MPBT data peeks from the DirectDraw shim''s blit diagnostics and switch the log file append path to Win32 I/O
- only skip `vcvarsall` in `native\build.bat` when `cl.exe` and the required `INCLUDE` / `LIB` environment are already present

## Testing

- `npm run build:ddraw`
- `npm run build`
- `cargo check --manifest-path src-tauri\Cargo.toml`
- local v1.29 windowed sidecar probe no longer produced a fresh `DDRAW.dll` WER crash in the same connect/render window

## Checklist

- [x] Branch is based on `master`
- [x] Commit message follows `type: description`
- [x] Launcher builds cleanly (`npm run build:ddraw`, `npm run build`, `cargo check`)
- [x] No unrelated UI or generated schema changes are included
- [x] This PR is ready for review (not a draft)