### PR TITLE
[codex] fix windowed shim UI presents under FPS cap

### DIFF
--- a/native/ddraw.cpp
+++ b/native/ddraw.cpp
@@ -373,9 +373,9 @@ static LPARAM RemapMouseCoord(LPARAM lp) {
     return MAKELPARAM(gx, gy);
 }
 
-static void BlitToWindow() {
+static void BlitToWindow(bool forcePresent = false) {
     if (!g_hwnd || !g_backDib.hdc) return;
-    if (!ShouldPresentNow()) return;
+    if (!forcePresent && !ShouldPresentNow()) return;
     static int s_btwCount = 0;
     ++s_btwCount;
     if (s_btwCount % 50 == 0) {
@@ -439,7 +439,19 @@ static LRESULT CALLBACK ShimWndProc(HWND hwnd, UINT msg, WPARAM wp, LPARAM lp) {
         RestoreNativeDisplayMode();
         PostQuitMessage(0);
     }
-    return CallWindowProcA(g_origWndProc, hwnd, msg, wp, lp);
+    LRESULT result = CallWindowProcA(g_origWndProc, hwnd, msg, wp, lp);
+    switch (msg) {
+    case WM_LBUTTONUP:
+    case WM_RBUTTONUP:
+    case WM_MBUTTONUP:
+    case WM_LBUTTONDBLCLK:
+    case WM_KEYUP:
+    case WM_CHAR:
+    case WM_COMMAND:
+        BlitToWindow(true);
+        break;
+    }
+    return result;
 }
 
 // ============================================================================
@@ -589,7 +601,10 @@ public:
         *phdc = dib().hdc;
         return S_OK;
     }
-    HRESULT STDMETHODCALLTYPE ReleaseDC(HDC) override { return S_OK; }
+    HRESULT STDMETHODCALLTYPE ReleaseDC(HDC) override {
+        if (m_isPrimary || m_isBack) BlitToWindow(true);
+        return S_OK;
+    }
 
     HRESULT STDMETHODCALLTYPE GetAttachedSurface(LPDDSCAPS,
                                                   LPDIRECTDRAWSURFACE* pp) override {


### PR DESCRIPTION
## Summary

Fixes the windowed DirectDraw shim so client-local UI transitions are presented immediately even when `fps_limit=60` is enabled. The shim now allows targeted forced presents for GDI/DC-driven UI updates and after input/menu messages return from MPBTWIN's window procedure, while ordinary render-loop paths remain FPS-capped.

## Related Issue

Closes #15

## Type of Change

- [x] Bug fix
- [ ] Feature / enhancement
- [ ] Research finding / protocol update
- [ ] Documentation update
- [ ] Refactor / internal cleanup
- [ ] Chore (dependencies, CI, config)

## Implementation Notes

- Adds an optional `forcePresent` flag to `BlitToWindow()` so selected UI flushes can bypass the frame gate without disabling the global FPS limiter.
- Flushes primary/backbuffer `ReleaseDC()` updates immediately, covering GDI/DC-drawn local UI.
- Forces one post-handler present after mouse/key/menu messages so local client dialogs and scene transitions are visible while the MPBT window remains focused.

## Testing

- Ran `native/build.bat` successfully to rebuild the x86 `ddraw.dll`.
- Staged the rebuilt DLL into the launcher-managed windowed client directory.
- Live-tested MPBTWIN v1.29 as Moose with `fps_limit=60`: clicking the center Solaris Starport icon now proceeds to the Bar/Booth scene without requiring MPBTWIN to lose focus.

## Checklist

- [x] Branch is based on `master`
- [x] Commit message follows `type: description` convention
- [x] Native shim builds cleanly
- [x] No debug logging added to production code paths
- [x] This PR is ready for review after maintainer validation
